### PR TITLE
Master Fork for Bigmaven Compatability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .byebug_history
+.idea
+.ruby-version
 active_record_query_trace-*.gem
 coverage/
 Gemfile.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ language: ruby
 # List of Ruby releases: https://www.ruby-lang.org/en/downloads/releases/
 # Maintenance status of each Ruby series https://www.ruby-lang.org/en/downloads/branches/
 rvm:
+  - 2.3.3
+  - 2.3.4
+  - 2.3.8
   - 2.4.10
   - 2.5.8
   - 2.6.6
@@ -30,13 +33,14 @@ matrix:
   # Some Rails versions do not work with older Ruby versions.
   exclude:
     # Rails >= 6 requires Ruby version >= 2.5.0
-    - rvm: 2.4.10
+    - rvm: 2.3.8
       gemfile: Gemfile
-    - rvm: 2.4.10
+    - rvm: 2.3.8
       gemfile: gemfiles/railsmaster.gemfile
-    # sqlite3-1.3.13/lib/sqlite3/sqlite3_native.so: undefined symbol: rb_check_safe_obj
-    - rvm: ruby-head
-      gemfile: gemfiles/rails5.gemfile
+    - rvm: 2.4.4
+      gemfile: Gemfile
+    - rvm: 2.4.4
+      gemfile: gemfiles/railsmaster.gemfile
     # I was unable to get Ruby head to work with Bundler < 2, which is required by Rails ~> 4
     - rvm: 2.7.2
       gemfile: gemfiles/rails4.gemfile

--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,5 @@ source 'http://rubygems.org'
 gemspec
 
 # Use the most recent Rails release by default
-gem 'rails', '>= 6.0.0'
+gem 'rails', '~> 5.2'
 gem 'sqlite3', '~> 1.4.0'

--- a/active_record_query_trace.gemspec
+++ b/active_record_query_trace.gemspec
@@ -14,8 +14,8 @@ Gem::Specification.new do |s|
   s.homepage      = 'https://github.com/brunofacca/active-record-query-trace'
   s.files         = Dir['lib/**/*']
   s.license       = 'MIT'
-  s.required_ruby_version = '>= 2.4', '< 4.0'
-  s.add_development_dependency 'activerecord', '>= 4.0.0'
+  s.required_ruby_version = '>= 2.3.3', '< 4.0'
+  s.add_development_dependency 'activerecord', '~> 5.2'
   s.add_development_dependency 'pry', '~> 0.13.0'
   s.add_development_dependency 'pry-byebug', '~> 3.9.0'
   s.add_development_dependency 'rspec', '>= 3.8.0'


### PR DESCRIPTION
- Updates travis config to use the ruby version we are locked to
- Update the gemspec to the version of rails we are using
- Update the ruby version to support 2.3.3